### PR TITLE
Add configurable AssemblyAI API credentials and endpoint support

### DIFF
--- a/lang/en/fluencytrack.php
+++ b/lang/en/fluencytrack.php
@@ -2,5 +2,13 @@
 
 $string['pluginname'] = 'Fluency Track';
 $string['modulename'] = 'Fluency Track';
-$string['audioupload'] = 'Upload your audio file';
+$string['modulenameplural'] = 'Fluency Tracks';
+$string['modulename_help'] = 'An activity that lets students upload audio and get fluency + grammar feedback.';
+$string['uploadaudio'] = 'Upload your audio file';
 $string['fluencytrack:viewdashboard'] = 'View Teacher Dashboard';
+
+$string['assemblyai_api_key'] = 'AssemblyAI API Key';
+$string['assemblyai_api_key_desc'] = 'Enter your AssemblyAI API key for transcription.';
+
+$string['assemblyai_api_endpoint'] = 'AssemblyAI API Endpoint';
+$string['assemblyai_api_endpoint_desc'] = 'Enter the base URL for the AssemblyAI API (e.g., https://api.assemblyai.com/v2)';

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,22 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+if ($hassiteconfig) {
+    $settings = new admin_settingpage('modsettingfluencytrack', get_string('pluginname', 'mod_fluencytrack'));
+
+    $settings->add(new admin_setting_configtext(
+        'mod_fluencytrack/assemblyai_api_key',
+        get_string('assemblyai_api_key', 'mod_fluencytrack'),
+        get_string('assemblyai_api_key_desc', 'mod_fluencytrack'),
+        '25f52db7ddeb418cafbccabc63038230'
+    ));
+
+    $settings->add(new admin_setting_configtext(
+        'mod_fluencytrack/assemblyai_api_endpoint',
+        get_string('assemblyai_api_endpoint', 'mod_fluencytrack'),
+        get_string('assemblyai_api_endpoint_desc', 'mod_fluencytrack'),
+        'https://api.assemblyai.com/v2'
+    ));
+
+    $ADMIN->add('modsettings', $settings);
+}

--- a/version.php
+++ b/version.php
@@ -2,8 +2,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_fluencytrack';
-$plugin->version = 2025061901;
+$plugin->version = 2025061902;
 $plugin->requires = 2022041900; 
 $plugin->cron = 0;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = 'v1.0';
+$plugin->has_config = true;


### PR DESCRIPTION
- Introduced admin settings for API key and endpoint via settings.php
- Defined default values for AssemblyAI key and endpoint
- Updated assemblyai API class to dynamically use settings values
- Ensured fallback error messages when credentials are missing
- Added language strings for new settings fields
- Set has_config = true in version.php for plugin settings visibility